### PR TITLE
Updating to alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:9.5-slim
-RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM alpine:3.8
+RUN apk add --no-cache --virtual .build-deps ca-certificates
 
 COPY build/github-webhook-dco-labeler /github-webhook-dco-labeler
 


### PR DESCRIPTION
There are two main reasons for the switch:
1. Alpine provides for a smaller base image
2. Alpine has been fast at applying security fixes or does not
   have them due to fewer things being included. It has a
   smaller attack surface of bugs in the wild